### PR TITLE
TYPE-46 disallow user input after finish

### DIFF
--- a/cmd/typing-client/client.go
+++ b/cmd/typing-client/client.go
@@ -191,6 +191,12 @@ func UpdateYourself(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			}
 		} else {
 			switch msg.String() {
+			case "ctrl+c", "ctrl+q":
+				return m, tea.Quit
+
+			case "ctrl+b":
+				m.chosen = false
+
 			case "backspace":
 				if len(m.userSentence) > 0 {
 					m.userSentence = m.userSentence[:len(m.userSentence)-1]

--- a/cmd/typing-client/client.go
+++ b/cmd/typing-client/client.go
@@ -12,17 +12,27 @@ import (
 	"golang.org/x/term"
 )
 
+var (
+	cpm      float64
+	wpm      float64
+	accuracy float64
+)
+
 type model struct {
-	options         []string
-	cursor          int
-	chosen          bool
-	input           ti.Model
-	sentence        string
-	userSentence    string
-	time            time.Time
-	strokes         int
-	correct_strokes float64
-	completed       bool
+	sentence     string
+	userSentence string
+
+	strokes int
+	cursor  int
+
+	completed bool
+	chosen    bool
+
+	input ti.Model
+	time  time.Time
+
+	options        []string
+	correctStrokes float64
 }
 
 func initModel() model {
@@ -88,7 +98,7 @@ func UpdateChoice(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			m.chosen = true
 			m.userSentence = ""
 			m.sentence = utility.GetRandomSentence(10)
-			m.correct_strokes = 0
+			m.correctStrokes = 0
 			m.strokes = 0
 			m.completed = false
 		}
@@ -209,7 +219,7 @@ func UpdateYourself(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			m.userSentence += msg.String()
 
 			if msg.Runes[0] == rune(m.sentence[len(m.userSentence)-1]) {
-				m.correct_strokes++
+				m.correctStrokes++
 			}
 		}
 
@@ -222,7 +232,8 @@ func ViewResults(m model) string {
 	var results = ""
 
 	physicalWidth, physicalHeight, _ := term.GetSize(int(os.Stdout.Fd()))
-	cpm, wpm, accuracy := utility.CalculateStats(m.correct_strokes, m.strokes, m.time)
+
+	cpm, wpm, accuracy = utility.CalculateStats(m.correctStrokes, m.strokes, m.time)
 
 	var container = lg.NewStyle().
 		Width(physicalWidth).

--- a/cmd/typing-client/client.go
+++ b/cmd/typing-client/client.go
@@ -181,48 +181,52 @@ func UpdateYourself(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			m.time = time.Now()
 		}
 
-		switch msg.String() {
-		case "ctrl+c", "ctrl+q":
-			return m, tea.Quit
+		if m.completed {
+			switch msg.String() {
+			case "ctrl+c", "ctrl+q":
+				return m, tea.Quit
 
-		case "ctrl+b":
-			m.chosen = false
-
-		case "backspace":
-			if len(m.userSentence) > 0 {
-				m.userSentence = m.userSentence[:len(m.userSentence)-1]
-				return m, nil
-			}
-
-		case " ":
-			if len(m.userSentence) < len(m.sentence) {
-				m.userSentence += " "
-				return m, nil
-			}
-
-		case "enter":
-			if len(m.userSentence) == len(m.sentence) {
-				m.completed = true
+			case "ctrl+b":
 				m.chosen = false
 			}
+		} else {
+			switch msg.String() {
+			case "backspace":
+				if len(m.userSentence) > 0 {
+					m.userSentence = m.userSentence[:len(m.userSentence)-1]
+					return m, nil
+				}
 
-			return m, nil
-		}
+			case " ":
+				if len(m.userSentence) < len(m.sentence) {
+					m.userSentence += " "
+					return m, nil
+				}
 
-		if msg.Type != tea.KeyRunes {
-			return m, nil
-		}
+			case "enter":
+				if len(m.userSentence) == len(m.sentence) {
+					m.completed = true
+					m.chosen = false
+					cpm, wpm, accuracy = utility.CalculateStats(m.correctStrokes, m.strokes, m.time)
+				}
 
-		m.strokes++
+				return m, nil
+			}
 
-		if len(m.userSentence) < len(m.sentence) {
-			m.userSentence += msg.String()
+			if msg.Type != tea.KeyRunes {
+				return m, nil
+			}
 
-			if msg.Runes[0] == rune(m.sentence[len(m.userSentence)-1]) {
-				m.correctStrokes++
+			m.strokes++
+
+			if len(m.userSentence) < len(m.sentence) {
+				m.userSentence += msg.String()
+
+				if msg.Runes[0] == rune(m.sentence[len(m.userSentence)-1]) {
+					m.correctStrokes++
+				}
 			}
 		}
-
 	}
 
 	return m, nil
@@ -232,8 +236,6 @@ func ViewResults(m model) string {
 	var results = ""
 
 	physicalWidth, physicalHeight, _ := term.GetSize(int(os.Stdout.Fd()))
-
-	cpm, wpm, accuracy = utility.CalculateStats(m.correctStrokes, m.strokes, m.time)
 
 	var container = lg.NewStyle().
 		Width(physicalWidth).

--- a/cmd/typing-client/utility/utility.go
+++ b/cmd/typing-client/utility/utility.go
@@ -81,10 +81,10 @@ func HalfGen(j int, physicalWidth int, physicalHeight int, hex string) lg.Style 
 		PaddingTop((physicalHeight - j) / 2)
 }
 
-func CalculateStats(correct_strokes float64, strokes int, startTime time.Time) (float64, float64, float64) {
-	var cpm = (correct_strokes / time.Since(startTime).Minutes())
-	var wpm = (correct_strokes / 5) / (time.Since(startTime).Minutes())
-	var accuracy = ((correct_strokes / float64(strokes)) * 100)
+func CalculateStats(correctStrokes float64, strokes int, startTime time.Time) (float64, float64, float64) {
+	var cpm = (correctStrokes / time.Since(startTime).Minutes())
+	var wpm = (correctStrokes / 5) / (time.Since(startTime).Minutes())
+	var accuracy = ((correctStrokes / float64(strokes)) * 100)
 
 	return cpm, wpm, accuracy
 }


### PR DESCRIPTION
Now the user won't be able to update their stats post-game by clicking keys. Only issue is that the cases:

> 			case "ctrl+c", "ctrl+q":
> 				return m, tea.Quit
> 
> 			case "ctrl+b":
> 				m.chosen = false
> 			}

are repeated. Looking forward to your suggestion on how to battle this, maybe a seperate function?